### PR TITLE
Dynamic job positions parsing

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -25,3 +25,4 @@ gem 'font-awesome-sass', '~> 4.4.0', require: false
 
 gem 'middleman-minify-html'
 gem 'middleman-search_engine_sitemap'
+gem 'redcarpet', '~> 3.4'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -159,6 +159,7 @@ GEM
     rb-fsevent (0.10.3)
     rb-inotify (0.9.10)
       ffi (>= 0.5.0, < 2)
+    redcarpet (3.4.0)
     sass (3.4.25)
     servolux (0.13.0)
     sprockets (3.7.2)
@@ -188,6 +189,7 @@ DEPENDENCIES
   middleman-minify-html
   middleman-search_engine_sitemap
   middleman-sprockets
+  redcarpet (~> 3.4)
   tzinfo-data
   wdm (~> 0.1.0)
 

--- a/config.rb
+++ b/config.rb
@@ -19,6 +19,28 @@ helpers do
     image_tag source, options
   end
 
+  def job_positions
+    jobboard_repo_url = 'https://raw.githubusercontent.com/brug-be/jobboard/master/'
+    jobboard_md = open(jobboard_repo_url + 'README.md').read
+    opening_string_match = "## Open positions"
+    ending_string_match = "##"
+    positions_dump = jobboard_md[/#{opening_string_match}(.*?)#{ending_string_match}/m, 1]
+    matching_positions = positions_dump.scan(/\[([^\[\]]+)\]\(([^)]+)\)/)
+
+    positions = []
+    matching_positions.each do |position_name, position_path|
+      begin
+        position_md = open(jobboard_repo_url + position_path).read
+        positions << { name: position_name, path: position_path, content: position_md }
+      rescue
+        puts "Issue parsing position '#{position_name}'"
+      end
+    end
+
+    # Order by position date DESC
+    positions.sort_by { |position| position[:path] }.reverse
+  end
+
   def ruby_shops
     csv_data = open('https://raw.githubusercontent.com/brug-be/rubyshops/master/bnlrubyshops.csv').read
     hash = CSV.new(csv_data, headers: true, header_converters: :symbol)

--- a/source/positions.html.haml
+++ b/source/positions.html.haml
@@ -1,0 +1,27 @@
+---
+title: Open positions in the community - Ruby Belgium
+---
+- markdown = Redcarpet::Markdown.new(Redcarpet::Render::HTML, autolink: true, tables: true)
+
+%header.header
+  .layer
+    .container.text-center
+      %h1.animated.fadeInUp The #{job_positions.count} open positions to fill in the community
+      -# %h3.header__subtitle
+      -#   - job_positions.each_with_index do |group, index|
+      -#     - group_name = group[0]
+      -#     - unless index == 0
+      -#       = ' - '
+      -#     %a{href: "##{group_name.underscore}"}
+      -#       = group_name
+
+%section.section--alternate
+  .container
+    - job_positions.each do |position|
+      .row{id: position[:path]}
+        .col-lg-12
+          %h2.page-header.text-center
+            = position[:name]
+      .row
+        .col-md-12.col-sm-12
+          = markdown.render(position[:content])


### PR DESCRIPTION
This PR addresses the issue #88 .

The idea of the PR is to have a 1st version to display the positions on the website.
I feel like having an external link to a Github Repo is not enough of a proof of concept to learn anything from it and see if we can have an impact on this area.

On the other hand, I think that creating these markdowns files for each job is a good middle-ground for companies, as it's both easy and secured by the PR which is reviewed by the association.

This PR addresses this issue and tries to provide a first proof of concept to have these positions on the website.

This is a WIP for the moment, the view is "just" a dump of the parsed markdown in HTML. It works and markdown is being parsed, but it looks awful.

On the top of my head, here's what's missing:
- [ ] An index of all the position names at the top of the page
- [ ] Custom markdown renderer to force the markdown `# Title` to be `h3` instead of `h1` and so one for the next title levels. Otherwise, we end up with multiple `h1` and it breaks the architecture
- [ ] An accordion for each position. When you click on the name, you scroll and open this one, closes the others. This should work fine with anchor, and would be ideal to link positions with the URL

Bonus: 
- [ ] Use what is described at the previous point to share a specific position. Could be fairly easy IMO