### PR TITLE
Fixed github deploy action

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -7,6 +7,9 @@ on:
       - master
       - main
 
+permissions:
+  contents: write
+
 jobs:
   deploy:
     runs-on: ubuntu-latest
@@ -20,5 +23,10 @@ jobs:
         with:
           bundler-cache: true
 
-      - name: Build and Deploy 🚀
-        run: bundle exec mgd
+      - name: Build
+        run: bundle exec middleman build
+
+      - name: Deploy 🚀
+        uses: JamesIves/github-pages-deploy-action@v4
+        with:
+          folder: build

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,21 +1,24 @@
 ---
 name: Deploy to Github Pages
-​
+
 on:
   push:
     branches:
       - master
       - main
+
 jobs:
   deploy:
     runs-on: ubuntu-latest
+
     steps:
       - name: Checkout 🛎️
         uses: actions/checkout@v3
+
       - name: Set up Ruby
-        uses: actions/setup-ruby@v1
+        uses: ruby/setup-ruby@v1
         with:
-          ruby-version: 2.7.x
           bundler-cache: true
+
       - name: Build and Deploy 🚀
         run: bundle exec mgd


### PR DESCRIPTION
I had left a trailing whitespace in the yml file which broke the action.
I was also using the wrong version of `setup-ruby`
I fixed those two issues and tried again but then a problem came from `mgd`.
Apparently the gem is requiring some sort of authentification during his process which I wasn't doing in the action obviously
```
*** Please tell me who you are.

Run

  git config --global user.email "you@example.com"
  git config --global user.name "Your Name"

to set your account's default identity.
Omit --global to set the identity only in this repository.

fatal: empty ident name (for <runner@fv-az370-421.3txz4wqopyzepmqexx20lynywb.cx.internal.cloudapp.net>) not allowed
+ rm -rf /tmp/mgd-LHa
Error: deployment failed, see log above.
```

I fixed this by using another method for deployment.
Instead of using `mgd` I switch to a github action that I'm used to that does the same job except it won't build on its own.
So I first build the project with `bundle exec middleman build` as that's what `mgd` was using during its deployment and I then deploy to github with https://github.com/JamesIves/github-pages-deploy-action instead.
I also specified to deploy only the `build` folder in the `gh-pages` branch.

Everything is working now as you can see on my fork which I deployed with this action : http://rubybelgiumtest.site/
(Yes I bought a domain just to verify it works 😅 Sorry for not being more careful before doing the previous PR)